### PR TITLE
安装在用户目录下时, 找到PREF目录的正确位置

### DIFF
--- a/bcloud/Config.py
+++ b/bcloud/Config.py
@@ -17,7 +17,7 @@ if __file__.startswith('/usr/local/'):
 elif __file__.startswith('/usr/'):
     PREF = '/usr/share'
 elif __file__.startswith('/home/'):
-    PREF = os.path.expanduser("~") + '/.local/share'
+    PREF = os.path.join(os.path.expanduser("~"), '.local/share')
 else:
     PREF = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'share')
 

--- a/bcloud/Config.py
+++ b/bcloud/Config.py
@@ -16,6 +16,8 @@ if __file__.startswith('/usr/local/'):
     PREF = '/usr/local/share'
 elif __file__.startswith('/usr/'):
     PREF = '/usr/share'
+elif __file__.startswith('/home/'):
+    PREF = os.path.expanduser("~") + '/.local/share'
 else:
     PREF = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'share')
 


### PR DESCRIPTION
使用`pip3 install bcloud --user` 安装，以我的用户名为例，程序位于`/home/wzhd/.local/lib/python3.4/site-packages/bcloud/`，在Config.py设定PREF的部分，属于else，于是PREF被设定为`/home/wzhd/.local/lib/python3.4/site-packages/share/`，启动bcloud-gui时出现找不到文件`/home/wzhd/.local/lib/python3.4/site-packages/share/bcloud/bcloud.png`的情况, 实际上查看安装记录,在`/home/wzhd/.local/share/bcloud`目录，存在bcloud.png和color_schema.json，安装程序没有问题，只修改Config.py找到用户目录下的正确路径就可以了
