### PR TITLE
adjust width of the path button

### DIFF
--- a/bcloud/HomePage.py
+++ b/bcloud/HomePage.py
@@ -40,6 +40,7 @@ class PathBox(Gtk.Box):
         button = Gtk.Button.new_with_label(gutil.ellipse_text(name))
         button.abspath = abspath
         button.set_tooltip_text(name)
+        button.set_size_request(45, -1)
         self.pack_start(button, False, False, 0)
         button.connect('clicked', self.on_button_clicked)
 


### PR DESCRIPTION
因为按钮太窄的时候不太好点, 所以设置下最小宽度

before
![20141023a](https://cloud.githubusercontent.com/assets/760097/4750104/8dbbedae-5a8e-11e4-9915-a51b07187abc.png)

after
![20141023b](https://cloud.githubusercontent.com/assets/760097/4750106/9385cbce-5a8e-11e4-8959-13e045960899.png)
