### PR TITLE
Check keyring usability and disable remember password function accordingly

### DIFF
--- a/bcloud/SigninDialog.py
+++ b/bcloud/SigninDialog.py
@@ -180,7 +180,7 @@ class SigninDialog(Gtk.Dialog):
         box.show_all()
         self.infobar.hide()
 
-        if not hasattr(gutil, 'keyring'):
+        if not gutil.keyring_available:
             self.signin_check.set_active(False)
             self.signin_check.set_sensitive(False)
             self.remember_check.set_active(False)

--- a/bcloud/gutil.py
+++ b/bcloud/gutil.py
@@ -23,6 +23,12 @@ from bcloud import util
 try:
     import keyring
     keyring_available = True
+    try:
+        keyring.set_password("test", "utest", "ptest");
+        keyring.get_password("test", "utest");
+        keyring.delete_password("test", "utest");
+    except:
+        keyring_available = False
 except (ImportError, ValueError):
     logger.warn(traceback.format_exc())
     keyring_available = False


### PR DESCRIPTION
There are cases that we have the keyring module but it is actually unusable. Maybe because the user disabled keying service in System Settings (such as kwallet) or the keyring module fallback to a unusable backend due to lack of required packages for the most suitable backend.

This patch do some actual set_password and get_password operations after import the keyring module, if any exception happened, it will mark the keyring unavailable and cause the UI to disable the remember password function accordingly.
