### PR TITLE
fix: Failed to get bdstoken

### DIFF
--- a/bcloud/auth.py
+++ b/bcloud/auth.py
@@ -276,7 +276,7 @@ def parse_bdstoken(content):
     @return 返回bdstoken
     '''
     bdstoken = ''
-    bds_re = re.compile('BDSTOKEN\s*=\s*"([^"]+)"')
+    bds_re = re.compile('"bdstoken"\s*:\s*"([^"]+)"', re.IGNORECASE)
     bds_match = bds_re.search(content)
     if bds_match:
         bdstoken = bds_match.group(1)


### PR DESCRIPTION
Fix RegExpr to correctly match bdstoken.

New bdstoken looks like:

```
yunData.setData({...., "bdstoken":"abcdefghigklmnopqrstuvw","is_vip":0, ....});
```

This pull request changes the RegExpr in `bcloud/auth.py` to correctly match the bdstoken.

Fix this issue: https://github.com/LiuLang/bcloud/issues/213
